### PR TITLE
fix: Fix the name of the branch to use for auto deploys

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -3,7 +3,7 @@ name: Deploy to Dev ECS
 on:
   workflow_dispatch:
   push:
-    branches: [$default_branch]
+    branches: [main]
 
 jobs:
   deploy:


### PR DESCRIPTION
Asana ticket: [🐞 Automatically deploy to Dev when a branch is merged to main](https://app.asana.com/0/1199957631529739/1200386274942186)

The $default-branch placeholder can be used in workflow templates, but
not in an individual workflow.