### PR TITLE
fix: move checkout above use of .tool-versions

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -32,6 +32,9 @@ jobs:
           key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
       - uses: mbta/actions/reshim-asdf@v1
+      # The asdf job should have prepared the cache. exit if it didn't for some reason
+      - run: exit 1
+        if: steps.asdf-cache.outputs.cache-hit != 'true'
       - uses: actions/checkout@v2
       - name: Restore dependencies cache
         id: deps-cache

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: asdf
     steps:
+      - uses: actions/checkout@v2
       - name: ASDF cache
         uses: actions/cache@v2
         with:
@@ -35,7 +36,6 @@ jobs:
       # The asdf job should have prepared the cache. exit if it didn't for some reason
       - run: exit 1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
-      - uses: actions/checkout@v2
       - name: Restore dependencies cache
         id: deps-cache
         uses: actions/cache@v2


### PR DESCRIPTION
Taken from: https://github.com/mbta/.github/pull/8.