### PR TITLE
fix: Apply 2 fixes around document uploads

### DIFF
--- a/lib/document_viewer/uploads.ex
+++ b/lib/document_viewer/uploads.ex
@@ -9,11 +9,11 @@ defmodule DocumentViewer.Uploads do
           {:ok, %{bucket: String.t(), path: String.t()}} | :error
   def upload(file, original_filename, environment, form, opts \\ []) do
     put_object_fn = Keyword.get(opts, :put_object_fn, &ExAws.S3.put_object/3)
-    request_fn = Keyword.get(opts, :request_fn, &ExAws.stream!/1)
+    request_fn = Keyword.get(opts, :request_fn, &ExAws.request!/1)
 
     with bucket <- upload_bucket(),
          path <- unique_filename(original_filename, environment, form),
-         {:ok, %{status_code: 200}} <-
+         %{status_code: 200} <-
            bucket
            |> put_object_fn.(path, file)
            |> request_fn.() do

--- a/lib/document_viewer/uploads.ex
+++ b/lib/document_viewer/uploads.ex
@@ -33,6 +33,6 @@ defmodule DocumentViewer.Uploads do
     file_extension = Path.extname(filename)
     file_uuid = UUID.uuid4(:hex)
 
-    "#{environment}/#{form}/#{file_uuid}.#{file_extension}"
+    "#{environment}/#{form}/#{file_uuid}#{file_extension}"
   end
 end

--- a/test/document_viewer/uploads_test.exs
+++ b/test/document_viewer/uploads_test.exs
@@ -29,7 +29,7 @@ defmodule DocumentViewer.UploadsTest do
       {:ok, %{path: path}} =
         Uploads.upload(@mock_file, "test.jpg", "pre-prod", "youth-pass", opts)
 
-      assert Regex.match?(~r/^pre-prod\/youth-pass\/.+\.jpg$/, path)
+      assert Regex.match?(~r/^pre-prod\/youth-pass\/[0-9a-f]+\.jpg$/, path)
     end
 
     test "returns an error if the upload fails" do

--- a/test/document_viewer/uploads_test.exs
+++ b/test/document_viewer/uploads_test.exs
@@ -10,7 +10,7 @@ defmodule DocumentViewer.UploadsTest do
       opts = [
         put_object_fn: fn _, _, _ -> :ok end,
         request_fn: fn _ ->
-          {:ok, %{body: "", headers: [], status_code: 200}}
+          %{body: "", headers: [], status_code: 200}
         end
       ]
 
@@ -22,7 +22,7 @@ defmodule DocumentViewer.UploadsTest do
       opts = [
         put_object_fn: fn _, _, _ -> :ok end,
         request_fn: fn _ ->
-          {:ok, %{body: "", headers: [], status_code: 200}}
+          %{body: "", headers: [], status_code: 200}
         end
       ]
 
@@ -36,7 +36,7 @@ defmodule DocumentViewer.UploadsTest do
       opts = [
         put_object_fn: fn _, _, _ -> :ok end,
         request_fn: fn _ ->
-          {:ok, %{body: "", headers: [], status_code: 500}}
+          %{body: "", headers: [], status_code: 500}
         end
       ]
 


### PR DESCRIPTION
No Asana ticket.

fix: Use ExAws.request!/1 instead of stream
It appears request and not stream is what works properly for file puts.

fix: Remove an extra "." added before the file extension
Update the test regex to properly catch this.