### PR TITLE
feat: Return  an S3 URL from the upload endpoint

### DIFF
--- a/lib/document_viewer/uploads.ex
+++ b/lib/document_viewer/uploads.ex
@@ -4,9 +4,9 @@ defmodule DocumentViewer.Uploads do
   """
 
   @spec upload(binary(), String.t(), String.t(), String.t()) ::
-          {:ok, %{bucket: String.t(), path: String.t()}} | :error
+          {:ok, String.t()} | :error
   @spec upload(binary(), String.t(), String.t(), String.t(), keyword()) ::
-          {:ok, %{bucket: String.t(), path: String.t()}} | :error
+          {:ok, String.t()} | :error
   def upload(file, original_filename, environment, form, opts \\ []) do
     put_object_fn = Keyword.get(opts, :put_object_fn, &ExAws.S3.put_object/3)
     request_fn = Keyword.get(opts, :request_fn, &ExAws.request!/1)

--- a/lib/document_viewer/uploads.ex
+++ b/lib/document_viewer/uploads.ex
@@ -17,7 +17,7 @@ defmodule DocumentViewer.Uploads do
            bucket
            |> put_object_fn.(path, file)
            |> request_fn.() do
-      {:ok, %{bucket: bucket, path: path}}
+      {:ok, s3_url(bucket, path)}
     else
       _ -> :error
     end
@@ -35,4 +35,7 @@ defmodule DocumentViewer.Uploads do
 
     "#{environment}/#{form}/#{file_uuid}#{file_extension}"
   end
+
+  @spec s3_url(String.t(), String.t()) :: String.t()
+  defp s3_url(bucket, path), do: "https://#{bucket}.s3.amazonaws.com/#{path}"
 end

--- a/lib/document_viewer_web/controllers/upload_controller.ex
+++ b/lib/document_viewer_web/controllers/upload_controller.ex
@@ -12,9 +12,9 @@ defmodule DocumentViewerWeb.UploadController do
 
     {:ok, file_binary} = File.read(file.path)
 
-    {:ok, %{bucket: bucket, path: path}} = upload_fn.(file_binary, filename, environment, form)
+    {:ok, s3_url} = upload_fn.(file_binary, filename, environment, form)
 
-    json(conn, %{bucket: bucket, path: path})
+    json(conn, %{s3_url: s3_url})
   end
 
   def create(conn, _) do

--- a/test/document_viewer_web/controllers/upload_controller_test.exs
+++ b/test/document_viewer_web/controllers/upload_controller_test.exs
@@ -4,8 +4,10 @@ defmodule DocumentViewerWeb.UploadControllerTest do
   describe "create: POST /api/upload" do
     @tag :with_api_token
     test "returns the bucket and path where the file was uploaded", %{conn: conn} do
+      mock_s3_url = "https://TEST-BUCKET.s3.amazonaws.com/TEST-ENV/TEST-FORM/TEST-FILE.jpg"
+
       upload_fn = fn _, _, _, _ ->
-        {:ok, %{bucket: "TEST_BUCKET", path: "TEST_PATH"}}
+        {:ok, mock_s3_url}
       end
 
       upload = %Plug.Upload{
@@ -22,7 +24,7 @@ defmodule DocumentViewerWeb.UploadControllerTest do
           :form => "youth-pass"
         })
 
-      assert json_response(conn, 200) == %{"bucket" => "TEST_BUCKET", "path" => "TEST_PATH"}
+      assert json_response(conn, 200) == %{"s3_url" => mock_s3_url}
     end
 
     @tag :with_api_token


### PR DESCRIPTION
Asana ticket: [Document Viewer: Upload endpoint should return an S3 URL](https://app.asana.com/0/1200240595613188/1201342697672259)

The full URL is more useful in our SimpliGov workflow than the component
parts.