### PR TITLE
fix: Improve the pull script to be idempotent

### DIFF
--- a/lib/mix/tasks/pull_simpli_gov_uploads.ex
+++ b/lib/mix/tasks/pull_simpli_gov_uploads.ex
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.PullSimpliGovUploads do
     end
   end
 
-  def uploaded_workflow_ids() do
+  def uploaded_workflow_ids do
     :document_viewer
     |> Application.fetch_env!(:upload_bucket)
     |> ExAws.S3.list_objects_v2(prefix: "prod/youth-pass/")

--- a/lib/simpli_gov.ex
+++ b/lib/simpli_gov.ex
@@ -93,12 +93,12 @@ defmodule SimpliGov do
 
   # Returns a date-time for ten minutes ago, truncated to the nearest second,
   # and formatted using ISO 8601.
-  @spec ten_minutes_ago_string() :: String.t()
-  defp ten_minutes_ago_string do
-    "Etc/UTC"
-    |> DateTime.now!()
-    |> DateTime.add(-600, :second)
-    |> DateTime.truncate(:second)
-    |> DateTime.to_iso8601()
-  end
+  # @spec ten_minutes_ago_string() :: String.t()
+  # defp ten_minutes_ago_string do
+  #   "Etc/UTC"
+  #   |> DateTime.now!()
+  #   |> DateTime.add(-600, :second)
+  #   |> DateTime.truncate(:second)
+  #   |> DateTime.to_iso8601()
+  # end
 end

--- a/lib/simpli_gov.ex
+++ b/lib/simpli_gov.ex
@@ -58,7 +58,9 @@ defmodule SimpliGov do
       # Only pull documents attached to Youth Pass applications
       "WorkflowTemplateName eq 'Youth Pass'",
       # Wait for a period to give the "push" functionality a chance to copy the file over to S3
-      "WorkflowInstanceCreated lt #{ten_minutes_ago_string()}"
+      # "WorkflowInstanceCreated lt #{ten_minutes_ago_string()}"
+      # Query for only applications created at before 4pm eastern, 12/02/2021 when we started pushing
+      "WorkflowInstanceCreated lt 2021-12-02T21:00:00Z"
     ]
 
     opts = [


### PR DESCRIPTION
Follow-up work for Asana ticket: [Pull existing documents from SimpliGov](https://app.asana.com/0/1200240595613188/1201189202727068)

Skip workflows that have already been uploaded so that it's safe to run this repeatedly without duplication.

Adjust the workflow query to hard-code it to ignore any applications created after we started pushing documents into S3 programmatically.

I have run the script with these additions and uploaded documents for the 15 remaining workflows that weren't captured in the initial run.