### PR TITLE
ci: Pin workflows to Ubuntu version 20.04

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   asdf:
     name: ASDF
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
 
   build:
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: asdf
     env:
       SECRET_KEY_BASE: local_secret_key_base_at_least_64_bytes_________________________________


### PR DESCRIPTION
Running against version 21 is throwing SSL-related errors.