### PR TITLE
fix: Update runtime Alpine version to match build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY --from=assets-builder /root/priv/static ./priv/static
 RUN mix do compile --force, phx.digest, release
 
 # Finally, use an Alpine container for the runtime environment
-FROM alpine:3.15.4
+FROM alpine:3.16.2
 
 RUN apk add --update libssl1.1 ncurses-libs bash curl dumb-init \
   && apk upgrade \


### PR DESCRIPTION
Fixes failing deployments.

Successfully deploy to dev. ([Action](https://github.com/mbta/document_viewer/actions/runs/5282253481)) ([AWS](https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/document-viewer/services/document-viewer-dev/deployments?region=us-east-1))