### PR TITLE
ci: Ugrade upload-artifact action from v2 to v4

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -71,7 +71,7 @@ jobs:
           echo "${{ github.event.pull_request.head.sha }}" > cover/PR_SHA
         if: github.event.pull_request
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: elixir-lcov
           path: cover/


### PR DESCRIPTION
No ticket. This has started causing [CI runs to fail](https://github.com/mbta/document_viewer/actions/runs/11103339129/job/30845346241?pr=395).

v2 has been deprecated, per:
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/