### PR TITLE
chore: update to latest ubuntu runner and actions/cache@v4

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -9,13 +9,13 @@ concurrency:
 jobs:
   asdf:
     name: ASDF
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
       # cache the ASDF directory, using the values from .tool-versions
       - name: ASDF cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
@@ -31,14 +31,14 @@ jobs:
 
   build:
     name: Build and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: asdf
     env:
       SECRET_KEY_BASE: local_secret_key_base_at_least_64_bytes_________________________________
     steps:
       - uses: actions/checkout@v2
       - name: ASDF cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
@@ -49,7 +49,7 @@ jobs:
         if: steps.asdf-cache.outputs.cache-hit != 'true'
       - name: Restore dependencies cache
         id: deps-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             deps


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/1204871882394498/1209401107551773)

Interestingly enough, the changes to the runner were done in some places, but this does it in `elixir.yml` and then I'm updating the actions/cache@v2 -> v4 because that will be deprecated soon anyhow too. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209562733217895